### PR TITLE
Add fixes to work with 0.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zig-s3",
+    .name = .zig_s3,
     .version = "0.2.0",
+    .fingerprint = 0xf58a772c84221497,
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .dotenv = .{

--- a/src/s3/bucket/operations.zig
+++ b/src/s3/bucket/operations.zig
@@ -166,7 +166,7 @@ pub fn listBuckets(self: *S3Client) ![]BucketInfo {
         buckets.deinit();
     }
 
-    var it = std.mem.split(u8, body, "<Bucket>");
+    var it = std.mem.splitSequence(u8, body, "<Bucket>");
     _ = it.first(); // Skip first part before any <Bucket>
 
     while (it.next()) |bucket_xml| {

--- a/src/s3/object/operations.zig
+++ b/src/s3/object/operations.zig
@@ -214,7 +214,7 @@ pub fn listObjects(
     }
 
     // Simple XML parsing - look for <Contents> elements
-    var it = std.mem.split(u8, body, "<Contents>");
+    var it = std.mem.splitSequence(u8, body, "<Contents>");
     _ = it.first(); // Skip first part before any <Contents>
 
     while (it.next()) |object_xml| {


### PR DESCRIPTION
This is some basic hacks I did to get this to compile for Zig `0.14.0` - no guarantee that I changed `mem.split` to the correct function now that `mem.split` is a compiler error.

Working on figuring out how to run the tests locally, have minio running but need it to stop trying to access what is set in the `.env` directory.